### PR TITLE
Add "categories" section for VS Gallery publishing

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -14,6 +14,9 @@
 	"scope": [
 		"vso.release"
 	],
+	"categories": [
+		"Build and release"
+	],
 	"description": "Install (deploy) MSI files from a specified directory, optionally passing environment variables as MSI properties",
 	"tags": [
 		"release",


### PR DESCRIPTION
Without this, the extension currently gets put into the "Other" section of the gallery